### PR TITLE
[Docker]: Adds Dockerfile for automated builds and publishing to Docker Hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 release/
+pve_exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build
+FROM golang:alpine AS build
+
+RUN apk add --update git make build-base bash && \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /go/src/github.com/wakeful/pve_exporter
+COPY . /go/src/github.com/wakeful/pve_exporter
+RUN go get -v -u ./... && \
+    ./build.sh
+
+# Runtime
+FROM scratch
+
+COPY --from=build /go/src/github.com/wakeful/pve_exporter/release/pve_exporter-linux-amd64 /pve_exporter
+
+EXPOSE 9090/tcp
+
+ENTRYPOINT ["/pve_exporter"]
+CMD ["-h"]

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=$(git describe --tags --dirty)
+VERSION=$(git describe --always --tags --dirty)
 GO_BUILD_CMD="go build -a -installsuffix cgo"
 GO_BUILD_LDFLAGS="-s -w -X main.version=$VERSION"
 
@@ -17,6 +17,6 @@ for OS in ${BUILD_PLATFORMS[@]}; do
     echo "Building for $OS/$ARCH"
     GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD -ldflags "$GO_BUILD_LDFLAGS"\
      -o "release/$NAME" pve_exporter.go
-    shasum -a 256 "release/$NAME" > "release/$NAME".sha256
+    sha256sum "release/$NAME" > "release/$NAME".sha256
   done
 done


### PR DESCRIPTION
Test Plan: Works

```#!bash
prologic@Jamess-MacBook
Sun Apr 29 22:03:22
~/go/src/github.com/wakeful/pve_exporter
 (master) 0
$ docker run -i -t prologic/pve_exporter
Usage of /pve_exporter:
  -listen-address string
    	Address on which to expose metrics. (default ":9090")
  -password string
    	Password for accessing PVE API (default "1234")
  -pve-url string
    	URL to your PVE control panel (default "https://127.0.0.1:8006")
  -realm string
    	PAM / LDAP auth method (default "pam")
  -telemetry-path string
    	Path under which to expose metrics. (default "/metrics")
  -timeout int
    	set request timeout to n (seconds) (default 5)
  -user string
    	User name used for accessing PVE API (default "root")
  -version
    	show version and exit
```